### PR TITLE
Update environments and installation

### DIFF
--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -5,3 +5,4 @@ dependencies:
   - pytest-cov
   - pytest
   - pytest-xdist
+  - xarray

--- a/ci/upstream-dev-env.yml
+++ b/ci/upstream-dev-env.yml
@@ -7,5 +7,4 @@ dependencies:
   - pytest-xdist
   - pip
   - pip:
-    # Example
-    # - git+https://github.com/pydata/xarray.git
+    - git+https://github.com/pydata/xarray.git

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,6 +11,7 @@ Welcome to pyDOMCFG's documentation!
    :hidden:
    :caption: For users:
 
+   users/installing
    users/api
 
 .. toctree::

--- a/docs/users/installing.rst
+++ b/docs/users/installing.rst
@@ -1,0 +1,22 @@
+Installation
+============
+
+Required dependencies
+---------------------
+
+- Python (3.7 or later)
+- setuptools
+- `xarray <http://xarray.pydata.org/>`_
+- `numpy <http://www.numpy.org/>`_
+
+Instructions
+------------
+
+pyDOMCFG must be installed from source because
+it has not been released on `PyPi <https://pypi.org/>`_ yet.
+The best way to install all dependencies is to use `conda <http://conda.io/>`_.
+
+.. code-block:: sh
+
+    conda install -c conda-forge xarray pip
+    pip install git+https://github.com/pyNEMO/pyDOMCFG.git

--- a/docs/users/installing.rst
+++ b/docs/users/installing.rst
@@ -13,7 +13,7 @@ Instructions
 ------------
 
 pyDOMCFG must be installed from source because
-it has not been released on `PyPi <https://pypi.org/>`_ yet.
+it has not been released on `PyPI <https://pypi.org/>`_ yet.
 The best way to install all dependencies is to use `conda <http://conda.io/>`_.
 
 .. code-block:: sh

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,6 +11,7 @@ python_requires = >=3.7
 install_requires =
     setuptools
     xarray
+    numpy
 setup_requires =
     setuptools
     setuptools_scm


### PR DESCRIPTION
<!-- Remove check-list items that aren't relevant to your change -->

- [x] Passes `pre-commit run --all-files`
- [x] Project, label, and assignee tabs are populated

I forgot to add `xarray` in the environments. I.e., it was installed by `pip` because it's a dependency in `setup.cfg`. Better to use conda. Because of that, we were not actually testing the latest `xarray` installed from source. `numpy` is also dependency as we import it, but it's a depedencies of `xarray` as well so there's no need to explicitly install it.

I also added the installation page in the docs.