### PR TITLE
remove for loops

### DIFF
--- a/pydomcfg/domzgr/zco.py
+++ b/pydomcfg/domzgr/zco.py
@@ -139,7 +139,7 @@ class Zco(Zgr):
         ds = Dataset()
         ds["z3T"] = self.compute_z3(suT, s1T, a1, a2, a3, s2T, a4)
         ds["z3W"] = self.compute_z3(suW, s1W, a1, a2, a3, s2W, a4)
-        ds["z3W"] = ds["z3W"].where(ds["z"] > 0, 0)
+        ds["z3W"][{"z": 0}] = 0.0
 
         # compute e3 scale factors
         ds = self.compute_e3(ds).broadcast_like(self._bathy)

--- a/pydomcfg/domzgr/zco.py
+++ b/pydomcfg/domzgr/zco.py
@@ -139,6 +139,7 @@ class Zco(Zgr):
         ds = Dataset()
         ds["z3T"] = self.compute_z3(suT, s1T, a1, a2, a3, s2T, a4)
         ds["z3W"] = self.compute_z3(suW, s1W, a1, a2, a3, s2W, a4)
+        # force first w-level to be exactly at zero
         ds["z3W"][{"z": 0}] = 0.0
 
         # compute e3 scale factors

--- a/pydomcfg/domzgr/zco.py
+++ b/pydomcfg/domzgr/zco.py
@@ -142,7 +142,8 @@ class Zco(Zgr):
         ds["z3W"] = ds["z3W"].where(ds["z"] > 0, 0)
 
         # compute e3 scale factors
-        ds = self.compute_e3(ds).broadcast_like(ds)
+        ds = self.compute_e3(ds).broadcast_like(self._bathy)
+        ds = ds.set_coords(ds.variables)
 
         return self._bathy.merge(ds)
 

--- a/pydomcfg/domzgr/zco.py
+++ b/pydomcfg/domzgr/zco.py
@@ -143,7 +143,7 @@ class Zco(Zgr):
         ds["z3W"][{"z": 0}] = 0.0
 
         # compute e3 scale factors
-        ds = self.compute_e3(ds).broadcast_like(self._bathy)
+        ds = self.compute_e3(ds).broadcast_like(self._bathy["Bathymetry"])
         ds = ds.set_coords(ds.variables)
 
         return self._bathy.merge(ds)

--- a/pydomcfg/domzgr/zgr.py
+++ b/pydomcfg/domzgr/zgr.py
@@ -53,9 +53,8 @@ class Zgr:
         *) W-points are at integer values - 1/2 (between 0.5 and jpk-0.5)
         """
 
-        kindx = DataArray(
-            range(1, self._jpk + 1), coords={"z": range(self._jpk)}, dims="z"
-        ).astype(float)
+        kindx = DataArray(range(self._jpk), coords={"z": range(self._jpk)}, dims="z")
+        kindx = kindx + 1.0  # to deal with python convention
 
         if grd == "W":
             kindx -= 0.5

--- a/pydomcfg/domzgr/zgr.py
+++ b/pydomcfg/domzgr/zgr.py
@@ -133,7 +133,6 @@ class Zgr:
 
         # Bottom:
         for varname, k in zip(["e3T", "e3W"], [-1, 0]):
-            ds[varname] = ds[varname].fillna(
-                2.0 * (ds["z3T"][{"z": k}] - ds["z3W"][{"z": k}])
-            )
+            ds[varname][{"z": k}] = 2.0 * (ds["z3T"][{"z": k}] - ds["z3W"][{"z": k}])
+
         return ds


### PR DESCRIPTION
@oceandie 
There's a couple of things a think xarray can simplify:
1. No need to initialize variables. You can write the code without even knowing the shape of your variables (e.g., 1D z, 2D sigma, ..) and `xarray` will automatically broadcast whenever it's needed.
2. Because of that, you could get rid of a `for` loop you had in `__call__`
