### PR TITLE
Implement VerticalGridTuple

### DIFF
--- a/pydomcfg/domzgr/zco.py
+++ b/pydomcfg/domzgr/zco.py
@@ -234,7 +234,7 @@ class Zco(Zgr):
                 # Force first w-level to be exactly at zero
                 z3[{"z": 0}] = 0.0
 
-            z3_staggered += [z3]
+            z3_staggered.append(z3)
 
         return VerticalGridTuple(*z3_staggered)
 
@@ -251,7 +251,7 @@ class Zco(Zgr):
             e3 = DataArray((self._pphmax / (self._jpk - 1.0)))
             return VerticalGridTuple(t=e3, w=e3)
 
-        both_e3 = []
+        e3_staggered = []
         for sigma in self._sigmas:
             # Stretched zco grid
             a0 = self._ppa0
@@ -266,9 +266,9 @@ class Zco(Zgr):
                 tanh2 = np.tanh((kk - self._ppkth2) / self._ppacr2)
                 e3 += a2 * tanh2
 
-            both_e3 += [e3]
+            e3_staggered.append(e3)
 
-        return VerticalGridTuple(*both_e3)
+        return VerticalGridTuple(*e3_staggered)
 
     def _set_add_tanh2_and_pp2(
         self, pp2: Tuple[Optional[float], ...]

--- a/pydomcfg/utils.py
+++ b/pydomcfg/utils.py
@@ -3,7 +3,7 @@ Utilities
 """
 
 import inspect
-from collections import ChainMap
+from collections import ChainMap, namedtuple
 from functools import wraps
 from typing import Any, Callable, Mapping, Optional, Tuple, TypeVar, Union, cast
 
@@ -12,6 +12,8 @@ import xarray as xr
 from xarray import DataArray, Dataset
 
 F = TypeVar("F", bound=Callable[..., Any])
+
+VerticalGridTuple = namedtuple("VerticalGridTuple", ["t", "w"])
 
 
 def generate_cartesian_grid(


### PR DESCRIPTION
<!-- Remove check-list items that aren't relevant to your change -->

- [ ] Passes `pre-commit run --all-files`
- [ ] Project, label, and assignee tabs are populated

I recently discovered [namedtuple](https://docs.python.org/3/library/collections.html#collections.namedtuple), and I think we could make use of it in many places.
For example, accessing sigma on the t grid doing `sigmas.t` seems more robust (and readable?) than `sigmas[0]`.

We could use it for pps as well (e.g., place all tanh2 parameters in a named tuple and access those like this `pp_tanh2.a2`).