### PR TITLE
deprecate 3.7 - add 3.10

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9"]
+        python-version: ["3.8", "3.9", "3.10"]
     steps:
       - uses: actions/checkout@v2
       - uses: conda-incubator/setup-miniconda@v2

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,10 +5,17 @@
 # Required
 version: 2
 
+# Use mamba
+build:
+  os: ubuntu-20.04
+  tools:
+    python: mambaforge-4.10
+
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
    configuration: docs/conf.py
 
 # Optionally set the version of Python and requirements required to build your docs
+
 conda:
   environment: ci/docs.yml

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,7 @@ url = https://github.com/pyNEMO/pyDOMCFG
 packages = pydomcfg
 zip_safe = False  # https://mypy.readthedocs.io/en/latest/installed_packages.html
 include_package_data = True
-python_requires = >=3.7
+python_requires = >=3.8
 install_requires =
     setuptools
     xarray


### PR DESCRIPTION
If all tests pass, I suggest we add support for 3.10 and we deprecate 3.7.
That way we can use the [new features introduced in python 3.8](https://docs.python.org/3/whatsnew/3.8.html) (such as the walrus operator `:=`)

![image](https://user-images.githubusercontent.com/22245117/151396226-5658e8e5-88bf-4a04-b233-7eaab0f31743.png)
